### PR TITLE
Handle multiple note entries for a single task

### DIFF
--- a/dist/add-tasks.js
+++ b/dist/add-tasks.js
@@ -80,7 +80,7 @@ var config = _interopRequireWildcard(__webpack_require__(1));
 
 var _draftsTemplateParser = __webpack_require__(2);
 
-var _Autotagger = __webpack_require__(3);
+var _AutoTagger = __webpack_require__(3);
 
 var _TasksParser = __webpack_require__(6);
 
@@ -89,7 +89,7 @@ var _Project = __webpack_require__(10);
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 var configNote = getConfig();
-var autotagger = new _Autotagger.Autotagger(configNote);
+var autotagger = new _AutoTagger.Autotagger(configNote);
 var parser = new _TasksParser.TasksParser(autotagger);
 var document = getDocument();
 var templateParser = new _draftsTemplateParser.TemplateTagParser(document);
@@ -632,7 +632,7 @@ function () {
     }, {
       symbol: '🗒',
       type: 'notes',
-      format: 'string'
+      format: 'array'
     }, {
       symbol: '🔘',
       type: 'checklistItem',
@@ -770,6 +770,10 @@ function () {
               task.addChecklistItem(item[attr]);
               break;
 
+            case 'notes':
+              task.appendNotes(item[attr]);
+              break;
+
             default:
               task[attr] = item[attr];
           }
@@ -898,6 +902,22 @@ function () {
       })));
     }
     /**
+     * Appends a new line to the notes.
+     * @param {String|String[]} notes - An array or single string of notes
+     */
+
+  }, {
+    key: "appendNotes",
+    value: function appendNotes(notes) {
+      if (typeof notes == 'string') notes = [notes];
+
+      if (this.attributes.notes) {
+        this.attributes.notes += '\n' + notes.join('\n');
+      } else {
+        this.attributes.notes = notes.join('\n');
+      }
+    }
+    /**
      * Export the current to-do, with all defined attributes,
      * as an object to be passed to the things:/// URL scheme.
      * @see {@link https://support.culturedcode.com/customer/en/portal/articles/2803573#json|Things API documentation}
@@ -987,13 +1007,14 @@ function () {
       var autotagged = this._autotagger.parse(value);
 
       if (!autotagged) return;
-      var properties = 'list when reminder deadline notes heading checklistItem';
+      var properties = 'list when reminder deadline heading checklistItem';
       properties.split(' ').forEach(function (property) {
         if (!autotagged[property]) return;
         _this[property] = autotagged[property];
       });
       this.addTags(autotagged.tags || '');
       this.addChecklistItem(autotagged.checklistItem || []);
+      this.appendNotes(autotagged.notes || '');
     }
     /**
      * The start date of the to-do. Values can be "today",

--- a/src/add-tasks.js
+++ b/src/add-tasks.js
@@ -1,6 +1,6 @@
 import * as config from './config';
 import { TemplateTagParser } from 'drafts-template-parser';
-import { Autotagger } from './lib/Autotagger';
+import { Autotagger } from './lib/AutoTagger';
 import { TasksParser } from './lib/TasksParser';
 import { Project } from './lib/Project';
 

--- a/src/lib/Symbols.js
+++ b/src/lib/Symbols.js
@@ -14,7 +14,7 @@ export class Symbols {
 			{ symbol: '⏰', type: 'reminder',      format: 'string' },
 			{ symbol: '⚠️', type: 'deadline',      format: 'string' },
 			{ symbol: '📌', type: 'heading',       format: 'string' },
-			{ symbol: '🗒', type: 'notes',         format: 'string' },
+			{ symbol: '🗒', type: 'notes',         format: 'array' },
 			{ symbol: '🔘', type: 'checklistItem', format: 'array'  }
 		];
 	}

--- a/src/lib/Task.js
+++ b/src/lib/Task.js
@@ -70,7 +70,7 @@ export class Task {
 		let autotagged = this._autotagger.parse(value);
 		if (!autotagged) return;
 
-		const properties = 'list when reminder deadline notes heading checklistItem';
+		const properties = 'list when reminder deadline heading checklistItem';
 		properties.split(' ').forEach(property => {
 			if (!autotagged[property]) return;
 			this[property] = autotagged[property];
@@ -78,6 +78,7 @@ export class Task {
 
 		this.addTags(autotagged.tags || '');
 		this.addChecklistItem(autotagged.checklistItem || []);
+		this.appendNotes(autotagged.notes || '');
 	}
 
 	/**
@@ -125,6 +126,19 @@ export class Task {
 	addTags(tags) {
 		if (typeof tags == 'string') tags = tags.split(',');
 		this.attributes.tags.push(...tags.map(tag => tag.trim()));
+	}
+
+	/**
+	 * Appends a new line to the notes.
+	 * @param {String|String[]} notes - An array or single string of notes
+	 */
+	appendNotes(notes) {
+	    if (typeof notes == 'string') notes = [notes];
+	    if (this.attributes.notes) {
+	        this.attributes.notes += '\n' + notes.join('\n');
+	    } else {
+	        this.attributes.notes = notes.join('\n');
+	    }
 	}
 
 	/**

--- a/src/lib/TasksParser.js
+++ b/src/lib/TasksParser.js
@@ -30,6 +30,7 @@ export class TasksParser {
 				switch(attr) {
 					case 'tags': task.addTags(item[attr]); break;
 					case 'checklistItem': task.addChecklistItem(item[attr]); break;
+					case 'notes': task.appendNotes(item[attr]); break;
 					default: task[attr] = item[attr];
 				}
 			});


### PR DESCRIPTION
Updates the parser to handle multiple note entries for a single task, and combine them together into a single notes string field for sending to Things.